### PR TITLE
Fixes

### DIFF
--- a/src/main/java/io/github/apace100/apoli/power/PowerTypeRegistry.java
+++ b/src/main/java/io/github/apace100/apoli/power/PowerTypeRegistry.java
@@ -18,6 +18,7 @@ public class PowerTypeRegistry {
         if(idToPower.containsKey(id)) {
             throw new IllegalArgumentException("Duplicate power type id tried to register: '" + id.toString() + "'");
         }
+        disabledPowers.remove(id);
         idToPower.put(id, powerType);
         return powerType;
     }
@@ -39,7 +40,7 @@ public class PowerTypeRegistry {
         idToPower.remove(id);
     }
 
-    public static boolean wasDisabled(Identifier id) {
+    public static boolean isDisabled(Identifier id) {
         return disabledPowers.contains(id);
     }
 

--- a/src/main/java/io/github/apace100/apoli/power/PowerTypes.java
+++ b/src/main/java/io/github/apace100/apoli/power/PowerTypes.java
@@ -127,6 +127,7 @@ public class PowerTypes extends MultiJsonDataLoader implements IdentifiableResou
         Identifier factoryId = new Identifier(JsonHelper.getString(jo, "type"));
         int priority = JsonHelper.getInt(jo, "loading_priority", 0);
         if (!isResourceConditionValid(id, jo, priority)) {
+            LOADING_PRIORITIES.put(id, priority);
             return null;
         }
 


### PR DESCRIPTION
- If a new power is registered, and the disabledPowers set has the id, it will remove the id.
- Disabled Powers are now added to the loading priority map.
- Renamed `wasDisabled` to `isDisabled`.
  - This was the correct way to say it because it IS disabled at this very moment.